### PR TITLE
Using Embedded MongoDB on the tests

### DIFF
--- a/src/test/java/org/redlich/beers/BaseTest.java
+++ b/src/test/java/org/redlich/beers/BaseTest.java
@@ -27,7 +27,7 @@ import org.jboss.weld.junit5.auto.EnableAutoWeld;
 public abstract class BaseTest {
 
     static {
-        // System.setProperty(MongoDBDocumentConfigurations.HOST.get(), Database.INSTANCE.getConnectionString());
+         System.setProperty(MongoDBDocumentConfigurations.HOST.get(), Database.INSTANCE.getConnectionString());
     }
 
 }

--- a/src/test/java/org/redlich/beers/Database.java
+++ b/src/test/java/org/redlich/beers/Database.java
@@ -12,12 +12,16 @@ public enum Database {
 
     INSTANCE;
 
-    public MongoClient getMongoClient() {
-        return MongoClients.create(getConnectionString());
+    private final TransitionWalker.ReachedState<RunningMongodProcess> mongoRunningProcess;
+
+    Database() {
+        this.mongoRunningProcess = Mongod
+                .instance()
+                .start(Version.Main.V7_0);
     }
 
     public String getConnectionString() {
-        throw new UnsupportedOperationException("to be implemented!");
+        return connectionStringOf(mongoRunningProcess.current().getServerAddress());
     }
 
     private String connectionStringOf(ServerAddress serverAddress) {


### PR DESCRIPTION
## Changes
- Added an Embedded MongoDB into the `Database` enum to be used on the tests;
- Changed `BaseTest` class to set up the tests to connect to the Embedded MongoDB instance;